### PR TITLE
Update readme & link to python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://www.youtube.com/watch?v=UjsQFNN0nSA
 
 ### Plain instructions
 
-1. Make sure you've installed [Python 3.6 64 bit](https://www.python.org/ftp/python/3.6.5/python-3.6.5-amd64.exe). During installation:
+1. Make sure you've installed [Python 3.7 64 bit](https://www.python.org/downloads/). During installation:
    - Select "Add Python to PATH"
    - Make sure pip is included in the installation
 2. Open Rocket League


### PR DESCRIPTION
The [`rlbottraining`](https://pypi.org/project/rlbottraining/) dependency from requirements.txt now requires Python 3.7.

The python 3.6 link is now dead + attempting to run through the getting started setup with python 3.6 fails while trying to locate a compatible version of [`rlbottraining`](https://pypi.org/project/rlbottraining/)

Used the generic /downloads/ link since it has a big "Download Latest 3.7" button at the top and is less likely to go dead in the future.